### PR TITLE
Version 0.5.0

### DIFF
--- a/packages/sapling/deno.json
+++ b/packages/sapling/deno.json
@@ -2,12 +2,12 @@
   "name": "@sapling/sapling",
   "description": "A micro SSR framework",
   "license": "MIT",
-  "version": "0.4.3",
+  "version": "0.5.0",
   "imports": {
     "@std/media-types": "jsr:@std/media-types@^1.1.0",
     "@std/path": "jsr:@std/path@^1.0.8",
-    "@unocss/core": "npm:@unocss/core@^65.4.0",
-    "@unocss/preset-uno": "npm:@unocss/preset-uno@^65.4.0",
+    "@unocss/core": "npm:@unocss/core@^66.0.0",
+    "@unocss/preset-uno": "npm:@unocss/preset-uno@^66.0.0",
     "urlpattern-polyfill": "npm:urlpattern-polyfill@^10.0.0"
   },
   "exports": {

--- a/packages/sapling/src/constants.ts
+++ b/packages/sapling/src/constants.ts
@@ -1,1 +1,1 @@
-export const SAPLING_VERSION = "0.4.3";
+export const SAPLING_VERSION = "0.5.0";

--- a/packages/sapling/src/sapling-layout.ts
+++ b/packages/sapling/src/sapling-layout.ts
@@ -18,6 +18,8 @@ import { SAPLING_VERSION } from "./constants.ts";
  * @param props.stream - When true, returns a ReadableStream to stream the HTML output. Defaults to false
  * @param props.disableUnoCSS - When true, skips UnoCSS generation
  * @param props.enableIslands - When true, adds the islands script and CSS
+ * @param props.lang - Optional language for the HTML document
+ * @param props.disableGeneratorTag - When true, skips the generator meta tag
  *
  * @example
  * ```ts
@@ -67,11 +69,15 @@ export function Layout(props: LayoutProps): Promise<string> | ReadableStream {
       // Return the HTML as a string
       return `
         <!DOCTYPE html>
-        <html lang="en">
+        <html lang="${props.lang || "en"}">
         <head>
           <meta charset="UTF-8">
           <meta name="viewport" content="width=device-width, initial-scale=1.0">
-          <meta name="generator" content="Sapling v${SAPLING_VERSION}">
+          ${
+            props.disableGeneratorTag
+              ? ``
+              : `<meta name="generator" content="Sapling v${SAPLING_VERSION}">`
+          }
           ${props.disableTailwindReset ? `` : `<style>${resetStyles}</style>`}
           ${
             !props.disableUnoCSS
@@ -115,11 +121,15 @@ export function Layout(props: LayoutProps): Promise<string> | ReadableStream {
       controller.enqueue(
         new TextEncoder().encode(
           `<!DOCTYPE html>
-          <html lang="en">
+          <html lang="${props.lang || "en"}">
           <head>
             <meta charset="UTF-8">
             <meta name="viewport" content="width=device-width, initial-scale=1.0">
-            <meta name="generator" content="Sapling v${SAPLING_VERSION}">
+            ${
+              props.disableGeneratorTag
+                ? ``
+                : `<meta name="generator" content="Sapling v${SAPLING_VERSION}">`
+            }
             ${props.disableTailwindReset ? `` : `<style>${resetStyles}</style>`}
             ${
               !props.disableUnoCSS

--- a/packages/sapling/src/types/index.ts
+++ b/packages/sapling/src/types/index.ts
@@ -26,6 +26,10 @@ export interface LayoutProps {
    */
   enableIslands?: boolean;
   /**
+   * Whether to disable the generator meta tag
+   */
+  disableGeneratorTag?: boolean;
+  /**
    * The head content
    */
   head?: HtmlContent;
@@ -33,6 +37,10 @@ export interface LayoutProps {
    * Provide a custom body class
    */
   bodyClass?: string;
+  /**
+   * The language attribute for the HTML tag. Defaults to "en"
+   */
+  lang?: string;
   /**
    * The children content to render in the body of the page
    */


### PR DESCRIPTION
- added `lang` option to Sapling layout
- added `disableGeneratorTag` to disable the automatic Sapling generator tag 
